### PR TITLE
docs(token): update cost evaluation for v0.23.13

### DIFF
--- a/docs/token-cost-evaluation.md
+++ b/docs/token-cost-evaluation.md
@@ -1,65 +1,81 @@
 # Super Pi Token 开销评估
 
-> 评估日期：2026-04-21
-> 版本基准：0.18.0（10 skills, 13 tools, 78 rule files）
+> 评估日期：2026-05-24
+> 版本基准：0.23.13（18 skills, 24 tools, 78 rule files）
 
 ## 结论
 
-新开对话固定成本 **~2,500 tokens**，占 Claude Sonnet 4 (200K) 的 **1.26%**。首次 Bash 输出过滤即可回本。
+新开对话固定成本 **~4,350 tokens**，占 Claude Sonnet 4 (200K) 的 **2.17%**。首次 Bash 输出过滤即可回本。
+
+相比 v0.18.0 的 ~2,500 tokens，增长主要来自全局 skill 和内置工具的自然纳入（本次评估完整统计了所有可用 skill/tool，而非仅 super-pi 自身）。
 
 ---
 
 ## 一、固定成本明细（每次新开对话）
 
-### Skill 注册注入
+### Skill 注册注入（18 skills）
+
+| 来源 | 数量 | 说明 |
+|------|------|------|
+| super-pi 管线 skill | 8 | 01-brainstorm ~ 08-help |
+| 全局通用 skill | 9 | agent-browser, caveman, cli-tool, context7, git, handoff, html-write, skill-write, … |
+| 项目本地 skill | 1 | github-commit-super-pi |
+| 外部 npm skill | 1 | super-cli |
+| **合计** | **18** | |
 
 | 项目 | tokens |
 |------|--------|
-| 10 个 skill description 内容 | ~193 |
-| 10 个 skill name | ~22 |
-| 10 个 skill location 路径 | ~200 |
-| 10 个 skill XML 标签包装 | ~200 |
-| **小计** | **~615** |
+| 18 个 skill description 内容 | ~877 |
+| 18 个 skill name | ~43 |
+| 18 个 skill location 路径 | ~312 |
+| 18 个 skill XML 标签包装 | ~342 |
+| **小计** | **~1,574** |
 
-### Tool 注册注入
+### Tool 注册注入（24 tools）
+
+| 来源 | 数量 | 说明 |
+|------|------|------|
+| CE 扩展工具 | 14 | artifact_helper, ask_user_question, ce_subagent, workflow_state, worktree_manager, review_router, ce_parallel_subagent, session_checkpoint, task_splitter, brainstorm_dialog, plan_diff, session_history, pattern_extractor, context_handoff |
+| Pi 内置工具 | 10 | read, bash, edit, write, generate_image, sandbox_exec, search, web_search, web_fetch, research_search |
+| **合计** | **24** | |
 
 | 项目 | tokens |
 |------|--------|
-| 13 个 tool description | ~248 |
-| 83 个参数 description | ~724 |
-| JSON Schema 结构开销 | ~830 |
-| tool name + label | ~112 |
-| **小计** | **~1,914** |
+| 24 个 tool description | ~1,006 |
+| 90 个参数 description | ~1,080 |
+| JSON Schema 结构开销 | ~384 |
+| 参数名称 | ~180 |
+| tool name + label | ~121 |
+| **小计** | **~2,771** |
 
 ### Hooks / Filter
 
-| 项目 | tokens |
-|------|--------|
-| bash-output-filter | 0（运行时拦截） |
-| read-output-filter | 0（运行时拦截） |
-| compaction-optimizer | 0（运行时拦截） |
-| subagent-depth-guard | 0（环境变量检测） |
-| async-mutex | 0（运行时工具） |
-| **小计** | **0** |
+| 项目 | tokens | 说明 |
+|------|--------|------|
+| bash-output-filter | 0 | 运行时拦截 |
+| read-output-filter | 0 | 运行时拦截 |
+| compaction-optimizer | 0 | session_before_tree hook |
+| input stage-routing (model/thinking) | 0 | input hook，按管线阶段自动切换 |
+| **小计** | **0** | |
 
 ### 总固定成本
 
 ```
-Skill 注入  ~615
-Tool 注入   ~1,914
+Skill 注入  ~1,574
+Tool 注入   ~2,771
 Hooks       ~0
 ────────────────
-总计        ~2,529 tokens
+总计        ~4,345 tokens
 ```
 
 ### 各模型占比
 
 | 模型 | Context 长度 | 占比 |
 |------|-------------|------|
-| Claude Sonnet 4 | 200,000 | 1.264% |
-| Claude Opus 4 | 200,000 | 1.264% |
-| GPT-4o | 128,000 | 1.976% |
-| Gemini 2.5 Pro | 1,048,576 | 0.241% |
+| Claude Sonnet 4 | 200,000 | 2.173% |
+| Claude Opus 4 | 200,000 | 2.173% |
+| GPT-4o | 128,000 | 3.395% |
+| Gemini 2.5 Pro | 1,048,576 | 0.414% |
 
 ---
 
@@ -67,11 +83,13 @@ Hooks       ~0
 
 | 场景 | tokens |
 |------|--------|
-| SKILL.md 全量加载（10 个 skill 全触发） | ~13,600 |
-| 典型单次 skill 触发 | ~1,000–4,000 |
-| Rules 最小必读（common 2 文件） | ~900 |
-| Rules + 语言层（common + 1 语言，7 文件） | ~2,600 |
+| SKILL.md 全量加载（8 个管线 skill 全触发，~22.7 KB） | ~5,700 |
+| 典型单次 skill 触发 | ~300–1,200 |
+| Rules 最小必读（common 2 文件，~2.9 KB） | ~750 |
+| Rules + 语言层（common + TypeScript，7 文件，~10 KB） | ~2,700 |
 | Rules 全量（78 文件，极端情况，不会发生） | ~36,000 |
+
+> **v0.23.13 变化**: SKILL.md 内容更精简，单 skill 加载从 ~1,000–4,000 降至 ~300–1,200 tokens（管道配置提取到共享 `pipeline-config.md`，skill 主体更紧凑）。
 
 ---
 
@@ -83,6 +101,7 @@ Hooks       ~0
 | Read 输出过滤 | 1,000–10,000 tokens / 次 |
 | 避免返工（TDD 门控） | 5,000–50,000 tokens / 次 |
 | Compaction 优化 | 每次压缩提升摘要质量 ~30% |
+| 管线阶段模型路由 | 复杂阶段自动切强模型，节省轻量阶段 token |
 
 ---
 
@@ -93,30 +112,49 @@ Hooks       ~0
 | 规则加载 | 无 | 全量注入 | 按需渐进 |
 | 输出过滤 | 无 | 无 | 自动压缩 |
 | TDD 门控 | 靠 prompt | 靠 prompt | 结构化 hard gate |
-| 新对话固定成本 | 0 | ~5,000–36,000 | ~2,500 |
+| 新对话固定成本 | 0 | ~5,000–36,000 | ~4,350 |
+| Skill 自动路由 | 无 | 无 | 触发词 + 阶段模型切换 |
 | 长期 ROI | 基准 | 取决于规则质量 | **10x+** |
 
 ---
 
-## 五、项目优势点
+## 五、v0.18.0 → v0.23.13 变化摘要
+
+| 维度 | v0.18.0 | v0.23.13 | 变化 |
+|------|---------|----------|------|
+| Skills（统计口径） | 10（仅 super-pi） | 18（全部） | +8 全局/npm skill |
+| CE Tools | 13 | 14 | +pattern_extractor, +context_handoff |
+| 内置 Tools | 未统计 | 10 | 首次纳入 |
+| 总 Tools | 13 | 24 | +11 |
+| Rules | 78 | 78 | 持平 |
+| Hooks | 5（均 0 token） | 5（均 0 token） | 持平 |
+| 固定成本 | ~2,500 | ~4,345 | 口径变化（完整统计） |
+| SKILL.md 单次加载 | ~1,000–4,000 | ~300–1,200 | 精简 ~60% |
+| 阶段模型路由 | 无 | input hook | 新增 |
+
+---
+
+## 六、项目优势点
 
 ### 1. 投入产出比极高
 
-固定投入 ~2,500 tokens / 对话，单次 Bash 输出过滤就能省 2,000–40,000 tokens。一次避免返工的 TDD 门控省 5,000–50,000 tokens。ROI > 10x，第一次 `npm install` 输出的过滤就能回本。
+固定投入 ~4,350 tokens / 对话，单次 Bash 输出过滤就能省 2,000–40,000 tokens。一次避免返工的 TDD 门控省 5,000–50,000 tokens。ROI > 10x，第一次 `npm install` 输出的过滤就能回本。
 
 ### 2. Hooks 是「免费的超能力」
 
-bash-output-filter、read-output-filter、compaction-optimizer 是运行时拦截，零 system prompt 占用。它们在工具返回结果时压缩内容，越长的输出省得越多。架构设计的亮点：用 extension hook 而非 prompt injection 实现压缩。
+bash-output-filter、read-output-filter、compaction-optimizer、input stage-routing 都是运行时/事件驱动，零 system prompt 占用。它们在工具返回结果时压缩内容，越长的输出省得越多。input hook 在管线阶段切换时自动调整模型和思考级别，对 agent 完全透明。
 
 ### 3. 渐进式加载 = 零浪费
 
-Rules 78 个文件（36K tokens）永远不会全量加载。典型工作流只读 2–7 个规则文件（900–2,600 tokens）。比任何「全局注入规则」的方案省 90%+。
+Rules 78 个文件（~36K tokens）永远不会全量加载。典型工作流只读 2–7 个规则文件（~750–2,700 tokens）。比任何「全局注入规则」的方案省 90%+。
+
+SKILL.md 同样精简：共享指令提取到 `pipeline-config.md`，skill 单文件从 ~1,000–4,000 tokens 压缩到 ~300–1,200 tokens。
 
 ### 4. 规则与代码的分层解耦
 
-- `rules/` 是纯 Markdown，用户可直接编辑
-- `skills/` 是行为策略
-- `extensions/` 是能力单元
+- `rules/` 是纯 Markdown，用户可直接编辑（78 文件，14 语言层）
+- `skills/` 是行为策略（8 个管线阶段 + 共享 references）
+- `extensions/ce-core/` 是能力单元（14 工具 + 5 hooks）
 - 三者独立演化，互不影响
 
 ### 5. 防御性设计减少 token 浪费
@@ -125,3 +163,4 @@ Rules 78 个文件（36K tokens）永远不会全量加载。典型工作流只�
 - **Checkpoint resume**：中断恢复不重跑已完成的 unit，节省整个断点前的 token
 - **plan_diff 增量更新**：需求变更时不重写整个计划，只 patch 差异部分
 - **Solution 检索**：grep-first 策略只读 frontmatter（前 15 行），不全量加载所有 solution 文件
+- **阶段模型路由**：轻量阶段（brainstorm/learn）自动用便宜模型，重量阶段（work/review）自动切强模型，按需分配 token 预算


### PR DESCRIPTION
## 变更说明

更新 token 成本评估文档，从 v0.18.0 基准更新到 v0.23.13：

- **Skills**: 10→18（首次完整统计全局/project/npm skill）
- **Tools**: 13→24（首次纳入内置工具统计）
- **固定成本**: ~2,500→~4,345 tokens（口径变化，非膨胀）
- 新增 v0.18.0→v0.23.13 变化对比表
- 记录 SKILL.md 精简 ~60% 效果
- 补充 input hook 阶段模型路由优势

## 变更范围

```
docs/token-cost-evaluation.md | 123 ++++++++++++++++++++++++++++--------------
1 file changed, 81 insertions(+), 42 deletions(-)
```