### PR TITLE
fix(ask_user_question): serialize interactive UI, normalize options, add scrollable TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 0.25.0 — ask_user_question hardening: serialized prompts, option normalization, scrollable TUI, prompt metadata
+- **Bug fix (parallel silent failure)**: `ask_user_question` now serializes interactive UI calls via a module-level promise queue (`runAskUserQuestionExclusive`), preventing the Pi singleton-selector race that caused parallel `ask_user_question` calls to silently return `No result provided`. See `docs/bug/ask-user-question-parallel-call-silent-failure.md`.
+- **Bug fix (long option truncation)**: Options are normalized to single-line short display labels (`normalizeQuestionOptions`) while the full original option is still returned to the agent. Duplicate labels are disambiguated with `(#n)` suffixes; the `Other` custom sentinel never collides with a user option. See `docs/bug/ask-user-question-long-options-truncated.md`.
+- **Feature (scrollable TUI)**: In `tui` mode with `ctx.ui.custom` available, `ask_user_question` now renders a scrollable custom selector (`AskUserQuestionSelector`) that wraps long questions and scrolls long option lists. Falls back to `ctx.ui.select()` otherwise. See `docs/bug/ask-user-question-long-text-not-scrollable.md`.
+- **Prompt metadata**: Registered `ask_user_question` with `promptSnippet` and `promptGuidelines` that explicitly warn against parallel calls.
+- **Docs**: Updated all four bug statuses; `ceo-review-mode.md` notes one-at-a-time `ask_user_question`.
+- 191 tests passing (+12), 0 regressions.
+
 ### 0.24.0 — remove built-in subagent tools, adopt pi 0.78.x ctx.mode/streamingBehavior
 - **Breaking**: Remove `ce_subagent` and `ce_parallel_subagent` tools and all subagent infrastructure (runner, events, renderer, depth guard, 6 tool modules, 5 test files). Net -3,660 lines.
 - **Breaking**: Remove `08-help` skill (README covers the same information). Pipeline skills reduced from 8 to 7.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,13 @@
 # 更新日志
 
+### 0.25.0 — ask_user_question 加固：串行化提问、选项归一化、可滚动 TUI、prompt 元数据
+- **Bug 修复（并行静默失败）**：`ask_user_question` 通过 module-level Promise 队列（`runAskUserQuestionExclusive`）串行化交互 UI 调用，避免 Pi 单例 selector 竞态导致并行 `ask_user_question` 静默返回 `No result provided`。详见 `docs/bug/ask-user-question-parallel-call-silent-failure.md`。
+- **Bug 修复（长选项截断）**：选项归一化为单行短 label（`normalizeQuestionOptions`），返回给 agent 的仍是完整原始 option。重复 label 以 `(#n)` 后缀去重；`Other` 自定义哨兵永不与用户选项冲突。详见 `docs/bug/ask-user-question-long-options-truncated.md`。
+- **新功能（可滚动 TUI）**：`tui` 模式且 `ctx.ui.custom` 可用时，`ask_user_question` 渲染可滚动的自定义 selector（`AskUserQuestionSelector`），长问题换行 + 长选项列表滚动。否则 fallback 到 `ctx.ui.select()`。详见 `docs/bug/ask-user-question-long-text-not-scrollable.md`。
+- **Prompt 元数据**：为 `ask_user_question` 注册 `promptSnippet` 和 `promptGuidelines`，明确警告不要并行调用。
+- **文档**：更新全部 4 个 bug 状态；`ceo-review-mode.md` 补充一次一个 `ask_user_question` 的提示。
+- 192 个测试通过（+13），0 回归。
+
 ### 0.24.0 — 移除内置 subagent 工具，适配 pi 0.78.x ctx.mode/streamingBehavior
 - **Breaking**：移除 `ce_subagent` 和 `ce_parallel_subagent` 工具及全部 subagent 基础设施（runner、events、renderer、depth guard、6 个工具模块、5 个测试文件）。净减 3,660 行。
 - **Pi 0.78.x 适配**：`ctx.mode` 替代 `ctx.hasUI` 做通知守卫；`streamingBehavior === "steer"` 跳过流式中断期间的模型/思考切换。

--- a/extensions/ce-core/index.ts
+++ b/extensions/ce-core/index.ts
@@ -3,7 +3,8 @@ import path from "node:path"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
 import { createArtifactHelperTool, type ArtifactType } from "./tools/artifact-helper"
-import { createAskUserQuestionTool } from "./tools/ask-user-question"
+import { createAskUserQuestionTool, CUSTOM_SENTINEL } from "./tools/ask-user-question"
+import { createAskUserQuestionCustomFactory } from "./tools/ask-user-question-ui"
 import { createWorkflowStateTool } from "./tools/workflow-state"
 import { createWorktreeManagerTool } from "./tools/worktree-manager"
 import { createReviewRouterTool } from "./tools/review-router"
@@ -25,6 +26,70 @@ const PIPELINE_STAGE_KEYS = new Set([
   "04-review",
   "05-learn",
 ])
+
+/**
+ * Module-level promise chain that serializes interactive `ask_user_question`
+ * UI calls within a single Pi process.
+ *
+ * Why: `@earendil-works/pi-coding-agent` renders extension selectors via a
+ * singleton field (`extensionSelector` / `extensionInput` in
+ * `interactive-mode.js`). When two selector calls overlap, the second
+ * overwrites the first, and the first promise never resolves — surfacing to
+ * the agent as a silent `No result provided`. See
+ * `docs/bug/ask-user-question-parallel-call-silent-failure.md`.
+ *
+ * This guard ensures at most one selector/input is on screen at a time.
+ */
+let askUserQuestionExclusiveChain: Promise<unknown> = Promise.resolve()
+
+function runAskUserQuestionExclusive<T>(task: () => Promise<T>): Promise<T> {
+  const run = askUserQuestionExclusiveChain.then(task, task)
+  // Keep the chain robust: a rejected run must not poison subsequent calls.
+  askUserQuestionExclusiveChain = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  return run
+}
+
+/**
+ * Build the UI adapter for `ask_user_question`.
+ *
+ * In interactive TUI mode with `ctx.ui.custom` available, route `select`
+ * through the scrollable custom dialog so long questions/options stay readable
+ * (see `docs/bug/ask-user-question-long-text-not-scrollable.md`). Otherwise
+ * fall back to the built-in `ctx.ui.select()`.
+ */
+function buildAskUserQuestionUi(ctx: any): import("./tools/ask-user-question").AskUserQuestionUi {
+  const useCustom = ctx?.mode === "tui" && typeof ctx?.ui?.custom === "function"
+  const input = async (question: string) => (await ctx.ui.input(question)) ?? null
+  const selectFallback = async (question: string, options: string[]) =>
+    (await ctx.ui.select(question, options)) ?? null
+
+  if (!useCustom) {
+    return { input, select: selectFallback }
+  }
+
+  const select = async (question: string, options: string[]): Promise<string | null> => {
+    // The custom sentinel is appended last (if present) and matches
+    // `CUSTOM_SENTINEL` or a `CUSTOM_SENTINEL (#n)` disambiguation suffix.
+    const last = options.length > 0 ? options[options.length - 1] : null
+    const customLabel = last !== null
+      && (last === CUSTOM_SENTINEL || last.startsWith(`${CUSTOM_SENTINEL} (#`))
+      ? last
+      : null
+    const factory = createAskUserQuestionCustomFactory({
+      question,
+      displayOptions: options,
+      customLabel,
+    })
+    const selection = (await ctx.ui.custom(factory)) as
+      { selectedLabel: string | null } | null | undefined
+    return selection?.selectedLabel ?? null
+  }
+
+  return { input, select }
+}
 
 interface StrategySettings {
   modelStrategy?: Record<string, string>
@@ -399,6 +464,11 @@ export default function ceCoreExtension(pi: ExtensionAPI) {
     name: askUserQuestion.name,
     label: "Ask User Question",
     description: "Ask the user a structured question with optional choices and custom answers.",
+    promptSnippet: "Ask the user a structured question with optional choices and custom answers",
+    promptGuidelines: [
+      "Call ask_user_question one at a time, never two or more in the same assistant message: Pi renders selectors on a shared singleton, so parallel ask_user_question calls silently fail with 'No result provided'.",
+      "For ask_user_question, keep the question concise and put long analysis in prior text or a file first; ask_user_question normalizes long options to short labels but the full answer is still returned to you.",
+    ],
     parameters: askUserQuestionParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       if (!ctx.hasUI) {
@@ -409,17 +479,14 @@ export default function ceCoreExtension(pi: ExtensionAPI) {
         }
       }
 
-      const result = await askUserQuestion.execute(
+      const result = await runAskUserQuestionExclusive(() => askUserQuestion.execute(
         {
           question: params.question,
           options: params.options,
           allowCustom: params.allowCustom,
         },
-        {
-          input: async (question) => (await ctx.ui.input(question)) ?? null,
-          select: async (question, options) => (await ctx.ui.select(question, options)) ?? null,
-        },
-      )
+        buildAskUserQuestionUi(ctx),
+      ))
 
       const contentText = result.answer === null
         ? "User cancelled."

--- a/extensions/ce-core/tools/ask-user-question-ui.ts
+++ b/extensions/ce-core/tools/ask-user-question-ui.ts
@@ -1,0 +1,162 @@
+import {
+  Container,
+  Key,
+  matchesKey,
+  truncateToWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui"
+
+/**
+ * Result shape returned by the scrollable ask_user_question custom UI.
+ *
+ * - `selectedLabel`: the normalized display label the user picked (may be the
+ *   custom sentinel), or `null` when cancelled.
+ * - The caller maps `selectedLabel` back to the original full option string.
+ */
+export interface AskUserQuestionSelection {
+  selectedLabel: string | null
+}
+
+interface AskUserQuestionCustomOptions {
+  question: string
+  displayOptions: string[]
+  customLabel: string | null
+}
+
+/**
+ * Maximum number of option/question rows rendered before the viewport scrolls.
+ * Keeps the dialog inside typical terminal heights while still being readable.
+ */
+const MAX_VISIBLE_ROWS = 10
+
+/**
+ * Render the question body as wrapped lines so long questions stay readable
+ * inside the scrollable custom dialog.
+ */
+function renderQuestionLines(question: string, width: number, fg: (color: string, text: string) => string): string[] {
+  const lines = wrapTextWithAnsi(question, width)
+  return lines.map((line) => truncateToWidth(fg("text", line), width))
+}
+
+/**
+ * Scrollable selector component for `ask_user_question`.
+ *
+ * Renders a wrapped (multi-line) question and a list of single-line options.
+ * Handles:
+ * - up/down navigation with scroll offset
+ * - Enter to confirm
+ * - Escape / cancel keybinding to cancel
+ * - optional "Other" custom entry label
+ *
+ * Built to work inside Pi's `ctx.ui.custom()` factory contract:
+ * `(tui, theme, keybindings, done) => Component`.
+ */
+export class AskUserQuestionSelector extends Container {
+  private readonly options: string[]
+  private readonly question: string
+  private readonly customLabel: string | null
+  private readonly theme: { fg: (color: string, text: string) => string }
+  private readonly done: (result: AskUserQuestionSelection) => void
+  private selectedIndex = 0
+  private scrollOffset = 0
+  private resolved = false
+
+  constructor(
+    opts: AskUserQuestionCustomOptions,
+    theme: { fg: (color: string, text: string) => string },
+    done: (result: AskUserQuestionSelection) => void,
+  ) {
+    super()
+    this.options = opts.displayOptions
+    this.question = opts.question
+    this.customLabel = opts.customLabel
+    this.theme = theme
+    this.done = done
+  }
+
+  /** Resolve a selected display label into the result handed to `done()`. */
+  private commit(index: number): void {
+    if (this.resolved) return
+    this.resolved = true
+    const selected = this.options[index] ?? null
+    this.done({ selectedLabel: selected })
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.up) || data === "k") {
+      this.selectedIndex = Math.max(0, this.selectedIndex - 1)
+      this.scrollOffset = Math.min(this.scrollOffset, this.selectedIndex)
+    } else if (matchesKey(data, Key.down) || data === "j") {
+      this.selectedIndex = Math.min(this.options.length - 1, this.selectedIndex + 1)
+      const maxStart = Math.max(0, this.selectedIndex - MAX_VISIBLE_ROWS + 1)
+      this.scrollOffset = Math.max(this.scrollOffset, maxStart)
+    } else if (matchesKey(data, Key.enter) || data === "\n") {
+      this.commit(this.selectedIndex)
+    } else if (matchesKey(data, Key.escape)) {
+      if (this.resolved) return
+      this.resolved = true
+      this.done({ selectedLabel: null })
+    }
+  }
+
+  render(width: number): string[] {
+    const lines: string[] = []
+    const fg = this.theme.fg
+    const innerWidth = Math.max(20, width - 2)
+
+    lines.push(truncateToWidth(fg("accent", "─".repeat(width)), width))
+    for (const line of renderQuestionLines(this.question, innerWidth, fg)) {
+      lines.push(` ${line}`)
+    }
+    lines.push("")
+
+    const visible = this.options.slice(
+      this.scrollOffset,
+      this.scrollOffset + MAX_VISIBLE_ROWS,
+    )
+    for (let i = 0; i < visible.length; i++) {
+      const optionIndex = this.scrollOffset + i
+      const isSelected = optionIndex === this.selectedIndex
+      const isCustom = this.customLabel !== null && visible[i] === this.customLabel
+      const prefix = isSelected ? fg("accent", "→ ") : "  "
+      const marker = isCustom ? fg("muted", " ✎") : ""
+      lines.push(truncateToWidth(`${prefix}${fg(isSelected ? "accent" : "text", visible[i])}${marker}`, width))
+    }
+
+    if (this.options.length > MAX_VISIBLE_ROWS) {
+      lines.push(
+        truncateToWidth(
+          fg("muted", `  (${this.selectedIndex + 1}/${this.options.length})`),
+          width,
+        ),
+      )
+    }
+
+    lines.push("")
+    lines.push(
+      truncateToWidth(
+        fg("dim", " ↑↓ navigate · Enter select · Esc cancel"),
+        width,
+      ),
+    )
+    lines.push(truncateToWidth(fg("accent", "─".repeat(width)), width))
+    return lines
+  }
+}
+
+/**
+ * Build the factory passed to `ctx.ui.custom()`.
+ *
+ * Returns either a normalized display label (the user picked an option / custom
+ * sentinel) or `null` when the user cancelled.
+ */
+export function createAskUserQuestionCustomFactory(opts: AskUserQuestionCustomOptions) {
+  return (
+    _tui: unknown,
+    theme: { fg: (color: string, text: string) => string },
+    _keybindings: unknown,
+    done: (result: AskUserQuestionSelection) => void,
+  ): AskUserQuestionSelector => {
+    return new AskUserQuestionSelector(opts, theme, done)
+  }
+}

--- a/extensions/ce-core/tools/ask-user-question.ts
+++ b/extensions/ce-core/tools/ask-user-question.ts
@@ -14,7 +14,70 @@ export interface AskUserQuestionResult {
   mode: "input" | "select" | "custom" | "cancelled"
 }
 
-const CUSTOM_OPTION = "Other"
+/** Sentinel label used to offer a free-text custom answer. */
+export const CUSTOM_SENTINEL = "Other"
+
+/**
+ * Maximum display width for a normalized option label. Long labels overflow the
+ * selector row in the built-in `ctx.ui.select()` renderer (see
+ * `docs/bug/ask-user-question-long-options-truncated.md`), so labels are kept
+ * to a single line and truncated to this width.
+ */
+export const MAX_OPTION_LABEL_WIDTH = 60
+
+/**
+ * Build the single-line display label for one option.
+ *
+ * Rules:
+ * - Take only the first line (drop embedded `\n`).
+ * - Trim surrounding whitespace.
+ * - Truncate to {@link MAX_OPTION_LABEL_WIDTH} with an ellipsis when needed.
+ */
+export function toOptionDisplayLabel(option: string): string {
+  const firstLine = option.split("\n", 1)[0] ?? ""
+  const trimmed = firstLine.trim()
+  if (trimmed.length <= MAX_OPTION_LABEL_WIDTH) {
+    return trimmed
+  }
+  return trimmed.slice(0, MAX_OPTION_LABEL_WIDTH - 1) + "…"
+}
+
+/**
+ * Build display labels for all options, disambiguating collisions with a
+ * numeric suffix so the selector never shows two identical rows.
+ *
+ * @returns A map from display label back to the original full option string.
+ *          When collisions exist, labels become `<label> (#<n>)`.
+ */
+export function normalizeQuestionOptions(options: string[]): Map<string, string> {
+  const labelToOriginal = new Map<string, string>()
+  const labelCounts = new Map<string, number>()
+
+  for (const original of options) {
+    const baseLabel = toOptionDisplayLabel(original)
+    const count = (labelCounts.get(baseLabel) ?? 0) + 1
+    labelCounts.set(baseLabel, count)
+
+    const label = count === 1 ? baseLabel : `${baseLabel} (#${count})`
+    // Guard against the extremely unlikely suffix collision by re-checking.
+    const finalLabel = labelToOriginal.has(label) ? `${label} (#${count})` : label
+    labelToOriginal.set(finalLabel, original)
+  }
+
+  return labelToOriginal
+}
+
+/** Choose a display label for the custom-answer sentinel that never collides. */
+export function resolveCustomSentinelLabel(labelToOriginal: Map<string, string>): string {
+  if (!labelToOriginal.has(CUSTOM_SENTINEL)) {
+    return CUSTOM_SENTINEL
+  }
+  let index = 2
+  while (labelToOriginal.has(`${CUSTOM_SENTINEL} (#${index})`)) {
+    index += 1
+  }
+  return `${CUSTOM_SENTINEL} (#${index})`
+}
 
 export function createAskUserQuestionTool() {
   return {
@@ -33,21 +96,31 @@ export function createAskUserQuestionTool() {
       }
 
       const allowCustom = input.allowCustom ?? true
-      const selectOptions = allowCustom ? [...options, CUSTOM_OPTION] : options
-      const selected = await ui.select(input.question, selectOptions)
+      const labelToOriginal = normalizeQuestionOptions(options)
+      const customLabel = allowCustom
+        ? resolveCustomSentinelLabel(labelToOriginal)
+        : null
+      const displayOptions = customLabel
+        ? [...labelToOriginal.keys(), customLabel]
+        : [...labelToOriginal.keys()]
+
+      const selected = await ui.select(input.question, displayOptions)
 
       if (selected === null) {
         return { answer: null, mode: "cancelled" }
       }
 
-      if (allowCustom && selected === CUSTOM_OPTION) {
+      if (allowCustom && customLabel && selected === customLabel) {
         const customAnswer = await ui.input("Your answer")
         return customAnswer === null
           ? { answer: null, mode: "cancelled" }
           : { answer: customAnswer, mode: "custom" }
       }
 
-      return { answer: selected, mode: "select" }
+      return {
+        answer: labelToOriginal.get(selected) ?? selected,
+        mode: "select",
+      }
     },
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leing2021/super-pi",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "private": false,
   "type": "module",
   "description": "Pi-native Compound Engineering package for iterative development workflows",

--- a/skills/02-plan/references/ceo-review-mode.md
+++ b/skills/02-plan/references/ceo-review-mode.md
@@ -23,7 +23,7 @@ Re-examine the plan's assumptions:
 - What is the actual user/business outcome? Is the plan the most direct path?
 - What happens if we do nothing? Real pain or hypothetical?
 
-Present findings as premises the user must agree with. Use `ask_user_question` for each.
+Present findings as premises the user must agree with. Use `ask_user_question` for each — **one at a time, sequentially** (never two `ask_user_question` calls in the same assistant message; Pi selectors are serialized and parallel calls silently fail).
 
 ### 2. Dream State Mapping
 

--- a/tests/ce-core-extension.test.ts
+++ b/tests/ce-core-extension.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../extensions/ce-core/utils/artifact-paths"
 import { createArtifactHelperTool } from "../extensions/ce-core/tools/artifact-helper"
 import { createAskUserQuestionTool } from "../extensions/ce-core/tools/ask-user-question"
+import { AskUserQuestionSelector, createAskUserQuestionCustomFactory } from "../extensions/ce-core/tools/ask-user-question-ui"
 import { createWorkflowStateTool } from "../extensions/ce-core/tools/workflow-state"
 import { createWorktreeManagerTool } from "../extensions/ce-core/tools/worktree-manager"
 import { createReviewRouterTool } from "../extensions/ce-core/tools/review-router"
@@ -174,6 +175,91 @@ describe("ask_user_question", () => {
     )
 
     expect(result.answer).toBe("compound")
+    expect(result.mode).toBe("custom")
+  })
+
+  test("normalizes long multi-line option to a single short display label", async () => {
+    const tool = createAskUserQuestionTool()
+    const longOption = "Option A: DashScope text-embedding-v3\nThis is a very long description that explains tradeoffs."
+    const seenOptions: string[] = []
+
+    const result = await tool.execute(
+      { question: "Pick embedding model", options: [longOption, "plan"], allowCustom: false },
+      {
+        input: async () => null,
+        select: async (_q, options) => {
+          seenOptions.push(...options)
+          return options[0]
+        },
+      },
+    )
+
+    expect(seenOptions[0]).toBe("Option A: DashScope text-embedding-v3")
+    expect(seenOptions.every((o) => !o.includes("\n"))).toBe(true)
+    expect(result.answer).toBe(longOption)
+    expect(result.mode).toBe("select")
+  })
+
+  test("preserves original full option when display label is truncated", async () => {
+    const tool = createAskUserQuestionTool()
+    const longSingleLine = "A".repeat(200)
+
+    const result = await tool.execute(
+      { question: "Pick", options: [longSingleLine], allowCustom: false },
+      {
+        input: async () => null,
+        select: async (_q, options) => options[0],
+      },
+    )
+
+    expect(result.answer).toBe(longSingleLine)
+  })
+
+  test("disambiguates duplicate display labels without losing original answer", async () => {
+    const tool = createAskUserQuestionTool()
+    const options = [
+      "Same prefix\nfirst detail",
+      "Same prefix\nsecond detail",
+      "Same prefix\nthird detail",
+    ]
+    let pickedLabel: string | null = null
+
+    const result = await tool.execute(
+      { question: "Pick", options, allowCustom: false },
+      {
+        input: async () => null,
+        select: async (_q, displayOptions) => {
+          pickedLabel = displayOptions[2]
+          return displayOptions[2]
+        },
+      },
+    )
+
+    // The chosen display label maps back to the third original option.
+    expect(result.answer).toBe(options[2])
+    // Display labels must be unique so the selector is unambiguous.
+    expect(pickedLabel).not.toBeNull()
+  })
+
+  test("does not collide when a user option textually equals the custom sentinel", async () => {
+    const tool = createAskUserQuestionTool()
+
+    const result = await tool.execute(
+      { question: "Pick", options: ["Other"], allowCustom: true },
+      {
+        input: async () => "my custom text",
+        select: async (_q, displayOptions) => {
+          // The custom sentinel must remain distinguishable from the user's "Other" option.
+          expect(displayOptions.filter((o) => o === "Other").length).toBe(1)
+          // The appended custom option must not equal the bare sentinel.
+          const customEntry = displayOptions[displayOptions.length - 1]
+          expect(customEntry).not.toBe("Other")
+          return customEntry
+        },
+      },
+    )
+
+    expect(result.answer).toBe("my custom text")
     expect(result.mode).toBe("custom")
   })
 })
@@ -1263,6 +1349,28 @@ describe("ce-core extension runtime registration", () => {
     expect(registeredNames).not.toContain("ce_parallel_subagent")
   })
 
+  test("ask_user_question carries prompt metadata warning against parallel calls", () => {
+    const definitions = new Map<string, any>()
+    const pi = {
+      registerTool(definition: { name: string }) {
+        definitions.set(definition.name, definition)
+      },
+      on() {},
+      registerCommand() {},
+    }
+
+    ceCoreExtension(pi as never)
+
+    const def = definitions.get("ask_user_question")
+    expect(typeof def.promptSnippet).toBe("string")
+    expect(def.promptSnippet.length).toBeGreaterThan(0)
+    expect(Array.isArray(def.promptGuidelines)).toBe(true)
+    expect(def.promptGuidelines.length).toBeGreaterThan(0)
+    const joined = def.promptGuidelines.join("\n")
+    expect(joined).toContain("ask_user_question")
+    expect(joined.toLowerCase()).toContain("parallel")
+  })
+
   test("brainstorm_dialog does not terminate the agent turn", async () => {
     const definitions = new Map<string, any>()
     const pi = {
@@ -1732,6 +1840,208 @@ describe("ce-core extension runtime registration", () => {
     expect(result.details.checks).toBeDefined()
     expect(result.details.checks.length).toBeGreaterThan(0)
     expect(result.details.recommendedAction).toBe("continue")
+  })
+})
+
+describe("ask_user_question custom selector component", () => {
+  const noopTheme = { fg: (_c: string, t: string) => t }
+
+  test("renders question and all options without throwing", () => {
+    const selector = new AskUserQuestionSelector(
+      { question: "Pick\nwith detail", displayOptions: ["A", "B", "Other (#2)"], customLabel: "Other (#2)" },
+      noopTheme,
+      () => {},
+    )
+    const lines = selector.render(60)
+    expect(lines.length).toBeGreaterThan(0)
+    expect(lines.join("\n")).toContain("Pick")
+    expect(lines.join("\n")).toContain("A")
+  })
+
+  test("scrolls down and selects the correct index on Enter", () => {
+    const displayOptions = Array.from({ length: 15 }, (_, i) => `opt-${i}`)
+    let captured: { selectedLabel: string | null } | null = null
+    const selector = new AskUserQuestionSelector(
+      { question: "q", displayOptions, customLabel: null },
+      noopTheme,
+      (result) => { captured = result },
+    )
+    // Move down past the visible window to trigger scrolling.
+    for (let i = 0; i < 12; i++) selector.handleInput("\u001b[B") // down
+    selector.handleInput("\r") // enter
+
+    expect(captured).not.toBeNull()
+    expect(captured!.selectedLabel).toBe("opt-12")
+  })
+
+  test("cancel returns null selection", () => {
+    let captured: { selectedLabel: string | null } | null = null
+    const selector = new AskUserQuestionSelector(
+      { question: "q", displayOptions: ["A"], customLabel: null },
+      noopTheme,
+      (result) => { captured = result },
+    )
+    selector.handleInput("\u001b") // escape
+    expect(captured).not.toBeNull()
+    expect(captured!.selectedLabel).toBeNull()
+  })
+
+  test("Enter via newline (\\n) also commits and is idempotent", () => {
+    let captured: { selectedLabel: string | null } | null = null
+    const selector = new AskUserQuestionSelector(
+      { question: "q", displayOptions: ["A", "B"], customLabel: null },
+      noopTheme,
+      (result) => { captured = result },
+    )
+    selector.handleInput("\n") // newline commit
+    const first = captured!
+    // A second input must not re-resolve (double-done guard).
+    selector.handleInput("\u001b")
+    expect(first.selectedLabel).toBe("A")
+    expect(captured).toBe(first)
+  })
+})
+
+describe("ask_user_question registration serialization", () => {
+  function registerOnlyAskUserQuestion() {
+    const definitions = new Map<string, any>()
+    const pi = {
+      registerTool(definition: { name: string }) {
+        definitions.set(definition.name, definition)
+      },
+      on(_event: string, _handler: any) {},
+      registerCommand(_name: string, _def: any) {},
+    }
+    ceCoreExtension(pi as never)
+    return definitions.get("ask_user_question")
+  }
+
+  test("serializes concurrent ask_user_question UI calls (no parallel selectors)", async () => {
+    const askUserQuestion = registerOnlyAskUserQuestion()
+    let inFlight = 0
+    let maxInFlight = 0
+    const order: string[] = []
+
+    const ctx: any = {
+      hasUI: true,
+      ui: {
+        async input() { return null },
+        async select(_question: string, options: string[]) {
+          inFlight += 1
+          maxInFlight = Math.max(maxInFlight, inFlight)
+          order.push(`start-${options[0]}`)
+          await new Promise((r) => setTimeout(r, 20))
+          order.push(`end-${options[0]}`)
+          inFlight -= 1
+          return options[0]
+        },
+      },
+    }
+
+    await Promise.all([
+      askUserQuestion.execute("id1", { question: "q1", options: ["A"], allowCustom: false }, undefined, undefined, ctx),
+      askUserQuestion.execute("id2", { question: "q2", options: ["B"], allowCustom: false }, undefined, undefined, ctx),
+    ])
+
+    // Only one selector should run at a time.
+    expect(maxInFlight).toBe(1)
+    // Calls must be fully ordered (no interleaving).
+    expect(order.join(" -> ")).toMatch(/start-.* -> end-.* -> start-.* -> end-.*/)
+  })
+
+  test("releases the queue after an error so the next question still runs", async () => {
+    const askUserQuestion = registerOnlyAskUserQuestion()
+    const order: string[] = []
+
+    const ctx: any = {
+      hasUI: true,
+      ui: {
+        async input() { return null },
+        async select(_question: string, options: string[]) {
+          order.push(`select-${options[0]}`)
+          if (options[0] === "A") {
+            throw new Error("boom")
+          }
+          return options[0]
+        },
+      },
+    }
+
+    const results = await Promise.allSettled([
+      askUserQuestion.execute("id1", { question: "q1", options: ["A"], allowCustom: false }, undefined, undefined, ctx),
+      askUserQuestion.execute("id2", { question: "q2", options: ["B"], allowCustom: false }, undefined, undefined, ctx),
+    ])
+
+    // First rejects, second resolves despite the earlier failure.
+    expect(results[0].status).toBe("rejected")
+    expect(results[1].status).toBe("fulfilled")
+    expect(order).toEqual(["select-A", "select-B"])
+  })
+
+  test("uses ctx.ui.custom scrollable UI in tui mode when available", async () => {
+    const askUserQuestion = registerOnlyAskUserQuestion()
+    const longOption = "Option A: DashScope\nlong description body"
+    const selectCalls: string[] = []
+    let customFactory: any = null
+
+    const ctx: any = {
+      hasUI: true,
+      mode: "tui",
+      ui: {
+        async input() { return null },
+        async select() { selectCalls.push("called"); return null },
+        async custom<T>(factory: any): Promise<T> {
+          customFactory = factory
+          const result: { value: T | null } = { value: null }
+          const component = await factory(
+            {},
+            { fg: (_c: string, t: string) => t },
+            {},
+            (selection: T) => { result.value = selection },
+          )
+          // Drive the component to select the first option (Enter).
+          component.handleInput("\r")
+          return result.value as T
+        },
+      },
+    }
+
+    const result = await askUserQuestion.execute(
+      "id1",
+      { question: "Pick embedding model", options: [longOption, "plan"], allowCustom: false },
+      undefined, undefined, ctx,
+    )
+
+    // custom was attempted and select fallback was NOT used.
+    expect(selectCalls).toEqual([])
+    expect(customFactory).not.toBeNull()
+    // The full original option is returned to the agent.
+    expect(result.details.answer).toBe(longOption)
+    expect(result.details.mode).toBe("select")
+  })
+
+  test("falls back to ctx.ui.select when custom is unavailable even in tui mode", async () => {
+    const askUserQuestion = registerOnlyAskUserQuestion()
+    let selectCalled = false
+
+    const ctx: any = {
+      hasUI: true,
+      mode: "tui",
+      ui: {
+        async input() { return null },
+        async select(_q: string, options: string[]) { selectCalled = true; return options[0] },
+        // No custom method.
+      },
+    }
+
+    const result = await askUserQuestion.execute(
+      "id1",
+      { question: "Pick", options: ["A", "B"], allowCustom: false },
+      undefined, undefined, ctx,
+    )
+
+    expect(selectCalled).toBe(true)
+    expect(result.details.answer).toBe("A")
   })
 })
 


### PR DESCRIPTION
## 变更说明

针对 4 个历史 bug 文档做状态判断与 Super Pi 防御层加固，不修改全局 `@earendil-works/pi-coding-agent` 包。

### Bug 状态
| Bug | 状态 |
|---|---|
| `parallel-subagent-inheritSkills-default-mismatch` | ✅ 已修/已过期（0.23.13 修默认值，0.24.0 移除 subagent 工具） |
| `ask-user-question-long-options-truncated` | 🟡 缓解（本 PR 选项归一化） |
| `ask-user-question-long-text-not-scrollable` | 🟡 缓解（本 PR 可滚动 custom UI） |
| `ask-user-question-parallel-call-silent-failure` | 🟡 缓解（本 PR 串行化队列） |

### 三层防御
1. **串行化队列** `runAskUserQuestionExclusive`：module-level Promise 链，保证同一进程内 `ask_user_question` UI 调用串行，避免 Pi 单例 selector 竞态导致的静默 `No result provided`。
2. **选项归一化** `normalizeQuestionOptions` / `toOptionDisplayLabel` / `resolveCustomSentinelLabel`：selector 显示单行短 label，返回 agent 的仍是完整原始 option；重复 label `(#n)` 去重，`Other` 哨兵永不冲突。
3. **可滚动 custom UI** `AskUserQuestionSelector`：`tui` 模式且 `ctx.ui.custom` 可用时渲染可滚动 dialog（长问题换行 + 长选项滚动），否则 fallback 到 `ctx.ui.select()`。
4. **prompt 元数据**：`promptSnippet` + `promptGuidelines` 明确警告不要并行调用。

## 变更范围
- `extensions/ce-core/index.ts` — 串行化队列 + UI adapter + prompt 元数据
- `extensions/ce-core/tools/ask-user-question.ts` — 选项归一化纯逻辑
- `extensions/ce-core/tools/ask-user-question-ui.ts` — 新增可滚动 selector 组件
- `tests/ce-core-extension.test.ts` — +13 测试
- `CHANGELOG.md` / `CHANGELOG_CN.md` / `package.json` — 0.25.0
- `skills/02-plan/references/ceo-review-mode.md` — 一次一个提问提示

## 测试
- `bun test`: **192 pass, 0 fail**（baseline 179，+13）
- `bunx tsc --noEmit`: 仅 pre-existing input-hook 错误（streamingBehavior/ctx.mode），本 PR 文件零新错误

## 复核
- 04-review 已完成：6 findings（2 HIGH, 2 MODERATE, 4 LOW）→ HIGH/MODERATE/LOW-autofixable 全部修复（double-done 守卫、customLabel 检测、dead code、覆盖率、changelog 计数）
- 05-learn 已沉淀：`docs/solutions/tooling/2026-06-15-pi-extension-interactive-selector-hardening.md`