### PR TITLE
fix(ask_user_question): declare pi-tui peer dep and harden label dedup

### DIFF
--- a/extensions/ce-core/tools/ask-user-question.ts
+++ b/extensions/ce-core/tools/ask-user-question.ts
@@ -58,10 +58,16 @@ export function normalizeQuestionOptions(options: string[]): Map<string, string>
     const count = (labelCounts.get(baseLabel) ?? 0) + 1
     labelCounts.set(baseLabel, count)
 
-    const label = count === 1 ? baseLabel : `${baseLabel} (#${count})`
-    // Guard against the extremely unlikely suffix collision by re-checking.
-    const finalLabel = labelToOriginal.has(label) ? `${label} (#${count})` : label
-    labelToOriginal.set(finalLabel, original)
+    // Start from the count-based suffix, then keep appending (#n) until we find
+    // a label that is truly unused. This handles pathological inputs where an
+    // option's own text already ends in `(#k)` and would otherwise collide.
+    let label = count === 1 ? baseLabel : `${baseLabel} (#${count})`
+    let dedup = count
+    while (labelToOriginal.has(label)) {
+      dedup += 1
+      label = `${baseLabel} (#${dedup})`
+    }
+    labelToOriginal.set(label, original)
   }
 
   return labelToOriginal

--- a/package.json
+++ b/package.json
@@ -36,10 +36,12 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0",
     "typebox": ">=1.0.0"
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.76.0",
+    "@earendil-works/pi-tui": "^0.76.0",
     "bun-types": "^1.3.12"
   },
   "pi": {

--- a/tests/ce-core-extension.test.ts
+++ b/tests/ce-core-extension.test.ts
@@ -9,7 +9,7 @@ import {
   getRunArtifactPath,
 } from "../extensions/ce-core/utils/artifact-paths"
 import { createArtifactHelperTool } from "../extensions/ce-core/tools/artifact-helper"
-import { createAskUserQuestionTool } from "../extensions/ce-core/tools/ask-user-question"
+import { createAskUserQuestionTool, normalizeQuestionOptions } from "../extensions/ce-core/tools/ask-user-question"
 import { AskUserQuestionSelector, createAskUserQuestionCustomFactory } from "../extensions/ce-core/tools/ask-user-question-ui"
 import { createWorkflowStateTool } from "../extensions/ce-core/tools/workflow-state"
 import { createWorktreeManagerTool } from "../extensions/ce-core/tools/worktree-manager"
@@ -261,6 +261,25 @@ describe("ask_user_question", () => {
 
     expect(result.answer).toBe("my custom text")
     expect(result.mode).toBe("custom")
+  })
+
+  test("normalizeQuestionOptions keeps iterating until labels are unique even when option text already ends in (#n)", () => {
+    // Pathological input: the second option's own text already matches the
+    // disambiguation suffix the first pass would generate. A single-retry
+    // guard would let the fourth "X" reuse a label and hide an option.
+    const options = ["X", "X (#2)", "X (#2) (#2)", "X"]
+    const labelToOriginal = normalizeQuestionOptions(options)
+
+    // Every label must be unique.
+    const labels = [...labelToOriginal.keys()]
+    expect(new Set(labels).size).toBe(labels.length)
+
+    // Every original option must be reachable from exactly one label.
+    const originals = [...labelToOriginal.values()]
+    expect(originals.sort()).toEqual([...options].sort())
+
+    // No display label may collide with an unrelated original's suffix form.
+    expect(labels.filter((l) => l === "X (#2)").length).toBe(1)
   })
 })
 


### PR DESCRIPTION
## 变更说明

Follow-up 修复 PR #6 的 Codex review findings（PR #6 已 merged，Codex review 在 merge 后到达）。

### Codex Findings 修复

| 级别 | 位置 | 问题 | 修复 |
|------|------|------|------|
| **P1** | `ask-user-question-ui.ts:7` | `@earendil-works/pi-tui` 顶层 import 未声明依赖，非 hoist 安装环境加载即 `ERR_MODULE_NOT_FOUND` | 加入 `peerDependencies` (`>=0.74.0`) + `devDependencies` (`^0.76.0`) |
| **P2** | `ask-user-question.ts:64` | 选项去重只重试一次，输入如 `['X','X (#2)','X (#2) (#2)','X']` 会复用 label 导致选项消失 | 改为 `while` 循环持续追加 `(#n)` 直到 label 真正唯一 |

## 变更范围
- `extensions/ce-core/tools/ask-user-question.ts` — while 循环去重
- `package.json` — pi-tui peer + dev 依赖声明
- `tests/ce-core-extension.test.ts` — +1 多碰撞去重单测

## 测试
- `bun test`: **193 pass, 0 fail**（baseline 192，+1）
- `bunx tsc --noEmit`: 仅 pre-existing 错误（streamingBehavior/ctx.mode），本 PR 零新错误