### PR TITLE
fix(ask-user-question): bind fg method to theme to prevent crash on render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.25.1 — fix ask_user_question crash: bind fg to this.theme
+- **Bug fix**: `AskUserQuestionSelector.render()` extracted `this.theme.fg` as a bare function, losing `this` binding. Calling `fg("accent", ...)` threw `TypeError: Cannot read properties of undefined (reading 'fgColors')`, crashing Pi on `ask_user_question` invoke. Fixed by adding `.bind(this.theme)`.
+- 193 tests passing, 0 regressions.
+
 ### 0.25.0 — ask_user_question hardening: serialized prompts, option normalization, scrollable TUI, prompt metadata
 - **Bug fix (parallel silent failure)**: `ask_user_question` now serializes interactive UI calls via a module-level promise queue (`runAskUserQuestionExclusive`), preventing the Pi singleton-selector race that caused parallel `ask_user_question` calls to silently return `No result provided`. See `docs/bug/ask-user-question-parallel-call-silent-failure.md`.
 - **Bug fix (long option truncation)**: Options are normalized to single-line short display labels (`normalizeQuestionOptions`) while the full original option is still returned to the agent. Duplicate labels are disambiguated with `(#n)` suffixes; the `Other` custom sentinel never collides with a user option. See `docs/bug/ask-user-question-long-options-truncated.md`.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,9 @@
 # 更新日志
 
+### 0.25.1 — 修复 ask_user_question 崩溃：绑定 fg 到 this.theme
+- **Bug 修复**：`AskUserQuestionSelector.render()` 将 `this.theme.fg` 提取为裸函数，丢失 `this` 绑定。调用 `fg("accent", ...)` 时抛出 `TypeError: Cannot read properties of undefined (reading 'fgColors')`，导致 `ask_user_question` 触发 Pi 崩溃。修复方式：添加 `.bind(this.theme)`。
+- 193 个测试通过，0 回归。
+
 ### 0.25.0 — ask_user_question 加固：串行化提问、选项归一化、可滚动 TUI、prompt 元数据
 - **Bug 修复（并行静默失败）**：`ask_user_question` 通过 module-level Promise 队列（`runAskUserQuestionExclusive`）串行化交互 UI 调用，避免 Pi 单例 selector 竞态导致并行 `ask_user_question` 静默返回 `No result provided`。详见 `docs/bug/ask-user-question-parallel-call-silent-failure.md`。
 - **Bug 修复（长选项截断）**：选项归一化为单行短 label（`normalizeQuestionOptions`），返回给 agent 的仍是完整原始 option。重复 label 以 `(#n)` 后缀去重；`Other` 自定义哨兵永不与用户选项冲突。详见 `docs/bug/ask-user-question-long-options-truncated.md`。

--- a/extensions/ce-core/tools/ask-user-question-ui.ts
+++ b/extensions/ce-core/tools/ask-user-question-ui.ts
@@ -101,7 +101,7 @@ export class AskUserQuestionSelector extends Container {
 
   render(width: number): string[] {
     const lines: string[] = []
-    const fg = this.theme.fg
+    const fg = this.theme.fg.bind(this.theme)
     const innerWidth = Math.max(20, width - 2)
 
     lines.push(truncateToWidth(fg("accent", "─".repeat(width)), width))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leing2021/super-pi",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": false,
   "type": "module",
   "description": "Pi-native Compound Engineering package for iterative development workflows",


### PR DESCRIPTION
## 变更说明

修复 `ask_user_question` 触发时 Pi 崩溃的问题。

**根因**：`AskUserQuestionSelector.render()` 中 `const fg = this.theme.fg` 将方法提取为裸函数，丢失 `this` 绑定。调用 `fg("accent", ...)` 时 `this.fgColors` 为 `undefined`，抛出 `TypeError: Cannot read properties of undefined (reading 'fgColors')`。

**修复**：`const fg = this.theme.fg.bind(this.theme)`

## 变更范围

```
extensions/ce-core/tools/ask-user-question-ui.ts | 2 +-
package.json                                      | 2 +-
CHANGELOG.md                                      | 4 ++++
CHANGELOG_CN.md                                   | 4 ++++
4 files changed, 10 insertions(+), 2 deletions(-)
```

## 测试

```
bun test: 193 pass, 0 fail, 0 regression
```