### PR TITLE
chore(release): v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 0.26.0 — absorb Matt Pocock skills methodology + external-resource verification gates
+- **Skill methodology absorbed**: Evaluated [Matt Pocock skills](https://github.com/mattpocock/skills) against super-pi's self-contained + artifact-driven constraints via a four-filter test (self-contained / artifact-driven / SKILL.md line-budget / testability). Six concepts passed, three deferred (wayfinder, tracer-bullet tickets, triage — all depend on issue trackers).
+- **New shared references** (all self-contained, no external path deps):
+  - `skills/references/domain-language.md` — `CONTEXT.md` glossary + ADR three-condition threshold + single/multi-context consumption contract.
+  - `skills/references/module-design.md` — deep-module vocabulary (module / interface / depth / seam / adapter / leverage / locality) + deletion test + interface-is-test-surface.
+- **Debug discipline strengthened** (`03-work/references/debug-discipline.md`, 53→123 lines): full diagnosis loop with 10 feedback-loop construction strategies, Phase 1 completion criterion (red-capable / deterministic / fast / agent-runnable), non-deterministic bug reproduction-rate strategy, minimise step, Phase 6 post-mortem handoff to `05-learn`.
+- **Review Spec axis**: `04-review` gains a sixth axis — spec-reviewer persona compares the diff against the originating plan (missing requirements / scope creep / wrong implementation) and traces back to the user's original brainstorm wording to catch directional misunderstandings the plan itself encoded.
+- **Out-of-scope knowledge base**: `05-learn` can now record rejected or already-implemented requests to `docs/out-of-scope/`, consumed by `01-brainstorm` and `02-plan` to prevent re-proposing settled work. Template at `skills/05-learn/assets/out-of-scope-template.md`; convention README tracked (static), runtime instances gitignored.
+- **External-resource verification gate** (`01-brainstorm/references/premise-challenge.md` rule 5): when the user references an existing resource, reverse-verify intent (incorporate vs already-handled) before scoping. Prevents the failure mode where a misunderstood signal propagates through all pipeline stages and surfaces only at merge.
+- **Tests**: 196 → 204 (+8 content-contract tests including a self-contained path scan and SKILL.md line-count guard).
+- **gitignore**: `docs/` exclusion refined to `docs/*` + explicit exceptions so static convention docs (out-of-scope/README) are tracked while runtime artifacts stay ignored.
+
 ### 0.25.3 — align with pi 0.79–0.80: CONFIG_DIR_NAME, accurate compaction hook docs, peerDep floor
 - **pi adaptation**: `readSettings` now uses pi's exported `CONFIG_DIR_NAME` (default `.pi`, user-configurable since pi 0.79.7) instead of hardcoded `.pi` paths, so super-pi reads `settings.json` correctly when the project config directory is customized.
 - **Fix (dead code + misleading comments)**: The `compaction-optimizer` previously claimed to hook `session_before_compact` but actually hooked `session_before_tree`. Comments now accurately describe which hook consumes `COMPACTION_FOCUS_INSTRUCTIONS` (`session_before_tree`, whose `customInstructions` return value pi consumes on `/tree` navigation) and why regular context compaction is NOT covered (pi's `SessionBeforeCompactResult` only accepts `cancel` or a full `compaction` replacement — no prompt-only injection field). Removed a no-op `session_before_compact` handler that added `emit()` overhead with zero benefit.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,17 @@
 # 更新日志
 
+### 0.26.0 — 吸纳 Matt Pocock skills 方法论 + 外部资源核实门禁
+- **方法论吸纳**：以四过滤器（自包含 / artifact-driven / SKILL.md 行数预算 / 可测试性）评估 [Matt Pocock skills](https://github.com/mattpocock/skills)，6 项通过、3 项排除（wayfinder、tracer-bullet ticket 化、triage——均依赖 issue tracker）。
+- **新增共享 references**（均自包含，无外部路径依赖）：
+  - `skills/references/domain-language.md` — `CONTEXT.md` 词汇表 + ADR 三条件门槛 + 单/多 context 消费契约。
+  - `skills/references/module-design.md` — deep-module 词汇表（module / interface / depth / seam / adapter / leverage / locality）+ 删除测试 + interface-is-test-surface。
+- **调试纪律强化**（`03-work/references/debug-discipline.md`，53→123 行）：完整诊断环，含 10 种反馈环构造策略、Phase 1 完成标准（red-capable / deterministic / fast / agent-runnable）、非确定性 bug 复现率策略、minimise 步骤、Phase 6 post-mortem 闭环交接 `05-learn`。
+- **Review Spec 轴**：`04-review` 新增第六轴——spec-reviewer persona 对比 diff 与原始 plan（missing / scope creep / wrong implementation），并回溯用户原始措辞（brainstorm scope）以捕获 plan 自身编码的方向性误解。
+- **Out-of-scope 知识库**：`05-learn` 可记录被拒或已实现需求到 `docs/out-of-scope/`，供 `01-brainstorm` 和 `02-plan` 消费以防重复提出。模板位于 `skills/05-learn/assets/out-of-scope-template.md`；约定 README 纳入版本控制（静态），运行时实例 gitignore。
+- **外部资源核实门禁**（`01-brainstorm/references/premise-challenge.md` rule 5）：用户提及已有资源时，scoping 前反向核实意图（纳入 vs 已解决）。防止误解信号贯穿全部 pipeline 阶段、仅在 merge 时暴露的失败模式。
+- **测试**：196 → 204（+8 内容契约测试，含自包含路径扫描与 SKILL.md 行数守护）。
+- **gitignore**：`docs/` 排除细化为 `docs/*` + 显式例外，使静态约定文档（out-of-scope/README）可追踪，运行时 artifact 仍忽略。
+
 ### 0.25.3 — 跟进 pi 0.79–0.80：CONFIG_DIR_NAME、修正 compaction hook 文档、peerDep 下限
 - **pi 适配**：`readSettings` 改用 pi 导出的 `CONFIG_DIR_NAME`（默认 `.pi`，pi 0.79.7 起可用户自定义）替代硬编码 `.pi` 路径，当项目配置目录被自定义时也能正确读取 `settings.json`。
 - **修复（死代码 + 注释误导）**：`compaction-optimizer` 此前注释声称 hook `session_before_compact`，实际 hook 的是 `session_before_tree`。注释现准确描述哪个 hook 消费 `COMPACTION_FOCUS_INSTRUCTIONS`（`session_before_tree`，其 `customInstructions` 返回值在 `/tree` 导航时被 pi 消费），以及为何常规上下文压缩未覆盖（pi 的 `SessionBeforeCompactResult` 只接受 `cancel` 或完整 `compaction` 替换——无 prompt-only 注入字段）。移除了一个无效的 `session_before_compact` handler（徒增 `emit()` 开销却零收益）。

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You: /skill:03-work docs/plans/plan.md
 | **01-brainstorm** | Structured multi-round discovery, domain vocabulary persistence | `brainstorm_dialog` |
 | **02-plan** | TDD-gated implementation units, optional CEO Review | `plan_diff` |
 | **03-work** | Inline execution, checkpoint resume, strict TDD, stop-the-line | `session_checkpoint`, `task_splitter` |
-| **04-review** | Auto-assigned reviewers, five-axis findings, autofix loop | `review_router` |
+| **04-review** | Auto-assigned reviewers, six-axis findings (Standards + Spec), autofix loop | `review_router` |
 | **05-learn** | Pattern extraction → searchable solution artifacts | `pattern_extractor` |
 | **06-next** | Next-step recommendation + workflow status | `workflow_state` |
 | **07-worktree** | Isolated git worktree development | `worktree_manager` |
@@ -114,7 +114,7 @@ Super Pi is not a fork or wrapper. It extracts useful methods from the projects 
 | [superpowers](https://github.com/obra/superpowers) | Strict TDD gates, design checklists, review discipline, and the idea that agents need hard gates instead of gentle suggestions. |
 | [compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) | The five-step think → plan → build → review → learn loop and the knowledge-compounding backbone. |
 | [gstack](https://github.com/garrytan/gstack) | YC-style forcing questions, CEO Review cognitive frameworks, browser QA patterns, failure maps, and evidence-first validation. |
-| [mattpocock/skills](https://github.com/mattpocock/skills) | Context glossary (`CONTEXT.md`) for cross-session term persistence, lightweight ADR with three-condition threshold, and feedback-loop-first debug discipline. Adopted as reference templates embedded into existing skills — no new skills or tools. |
+| [mattpocock/skills](https://github.com/mattpocock/skills) | Context glossary (`CONTEXT.md`) for cross-session term persistence, lightweight ADR with three-condition threshold, feedback-loop-first debug discipline (full diagnosis loop with completion criteria and post-mortem handoff), deep-module vocabulary, the review Spec axis (plan-vs-diff with traceback to original wording), and the out-of-scope knowledge base. Adopted as self-contained `skills/references/` — no external path deps, no issue-tracker deps. |
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -36,7 +36,7 @@ pi install npm:@leing2021/super-pi
 | **01-brainstorm** | YC 风格追问,三种模式(Startup/Builder/CE),领域词汇持久化 | `brainstorm_dialog` |
 | **02-plan** | RED→GREEN→REFACTOR,增量更新,可选 CEO Review | `plan_diff` |
 | **03-work** | inline 执行,断点续传,严格 TDD | `session_checkpoint`, `task_splitter` |
-| **04-review** | 自动分配评审,结构化发现,可选浏览器 QA | `review_router` |
+| **04-review** | 自动分配评审,六轴发现(Standards + Spec),自动修复循环 | `review_router` |
 | **05-learn** | 模式提取 → 可搜索知识卡片 | `pattern_extractor` |
 | **06-next** | 下一步推荐 + 完整状态报告 | `workflow_state` |
 | **07-worktree** | 隔离 git worktree 开发 | `worktree_manager` |
@@ -77,7 +77,7 @@ Super Pi 不是 fork，也不是 wrapper。它从下面这些项目中提取有�
 | [superpowers](https://github.com/obra/superpowers) | 严格 TDD gates、设计检查清单、review discipline，以及“agent 需要硬门禁而不是温和建议”的理念。 |
 | [compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) | think → plan → build → review → learn 五步循环，以及 knowledge compounding 的骨架。 |
 | [gstack](https://github.com/garrytan/gstack) | YC 式 forcing questions、CEO Review 认知框架、Browser QA 模式、failure maps、evidence-first validation。 |
-| [mattpocock/skills](https://github.com/mattpocock/skills) | 项目领域词汇表（`CONTEXT.md`）跨会话持久化、轻量 ADR 三条件门槛、反馈环优先的调试纪律。作为参考模板嵌入到现有 skill 中，不新增 skill 或 tool。 |
+| [mattpocock/skills](https://github.com/mattpocock/skills) | 项目领域词汇表（`CONTEXT.md`）跨会话持久化、轻量 ADR 三条件门槛、反馈环优先的调试纪律（含完整诊断环、完成标准、post-mortem 闭环）、deep-module 词汇表、review Spec 轴（plan 对比 diff 并回溯原始措辞）、out-of-scope 知识库。以自包含 `skills/references/` 形式纳入——无外部路径依赖、无 issue tracker 依赖。 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leing2021/super-pi",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "private": false,
   "type": "module",
   "description": "Pi-native Compound Engineering package for iterative development workflows",


### PR DESCRIPTION
- bump package.json 0.25.3 → 0.26.0
- CHANGELOG.md / CHANGELOG_CN.md: 0.26.0 entry
- README.md / README_CN.md: 04-review six-axis, mattpocock adoption scope

204 pass, 0 fail. tsc pre-existing error unrelated (ce-core-extension.test.ts:1920, not touched this release).